### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note
 --------
 Basically same as appcompat_v7 version 21, you can use appcompat_v7
 ```groovy
-compile 'com.android.support:appcompat-v7:21.0.+'
+implementation 'com.android.support:appcompat-v7:21.0.+'
 ```
 ```xml
 <style name="AppTheme" parent="Theme.AppCompat.Light">


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.